### PR TITLE
Implement getName to make sonata admin happy

### DIFF
--- a/Document/BaseBlock.php
+++ b/Document/BaseBlock.php
@@ -181,6 +181,10 @@ abstract class BaseBlock implements BlockInterface
         $this->name = $name;
     }
 
+    public function getName() {
+        return $this->name;
+    }
+
     /**
      * set parent document regardless of type
      *


### PR DESCRIPTION
When using the admin to manage blocks you need to implement getName
