### PR TITLE
Add settings to container block

### DIFF
--- a/Block/ContainerBlockService.php
+++ b/Block/ContainerBlockService.php
@@ -48,6 +48,14 @@ class ContainerBlockService extends BaseBlockService implements BlockServiceInte
     }
 
     /**
+     * @return string
+     */
+    protected function getTemplate()
+    {
+        return 'SymfonyCmfBlockBundle:Block:block_container.html.twig';
+    }
+
+    /**
      * @param \Sonata\BlockBundle\Model\BlockInterface $block
      * @param null|\Symfony\Component\HttpFoundation\Response $response
      * @param \Symfony\Component\HttpFoundation\Response $response
@@ -59,10 +67,18 @@ class ContainerBlockService extends BaseBlockService implements BlockServiceInte
         }
 
         if ($block->getEnabled()) {
+            // merge settings
+            $settings = is_array($block->getSettings()) ? array_merge($this->getDefaultSettings(), $block->getSettings()) : $this->getDefaultSettings();
+
+            $childBlocks = array();
             foreach ($block->getChildren()->getValues() as $childBlock) {
-                // TODO: not sure if this is the right way to merge the responses?
-                $response->setContent($response->getContent() . $this->blockRenderer->render($childBlock)->getContent());
+                $childBlocks[] =  $this->blockRenderer->render($childBlock)->getContent();
             }
+
+            return $this->renderResponse($this->getTemplate(), array(
+                'childBlocks' => $childBlocks,
+                'settings'    => $settings
+            ), $response);
         }
 
         return $response;
@@ -93,7 +109,11 @@ class ContainerBlockService extends BaseBlockService implements BlockServiceInte
      */
     public function getDefaultSettings()
     {
-        // TODO: Implement getDefaultSettings() method.
+        return array(
+            'divisibleBy'    => false,
+            'divisibleClass' => '',
+            'childClass'     => '',
+        );
     }
 
     /**

--- a/Resources/views/Block/block_container.html.twig
+++ b/Resources/views/Block/block_container.html.twig
@@ -1,0 +1,30 @@
+{% block block %}
+    {% for childBlock in childBlocks %}
+        {% if settings.divisibleBy and loop.first %}
+            {# start row #}
+            <div{% if settings.divisibleClass %} class="{{ settings.divisibleClass }}"{% endif %}>
+        {% endif %}
+
+        {% if settings.divisibleBy %}
+            {# start child #}
+            <div{% if settings.childClass %} class="{{ settings.childClass }}"{% endif %}>
+        {% endif %}
+        {{ childBlock|raw }}
+        {% if settings.divisibleBy %}
+            </div>{# end child #}
+        {% endif %}
+
+        {% if settings.divisibleBy %}
+            {% if settings.divisibleBy and loop.index is divisibleby(settings.divisibleBy) %}
+                </div>{# end row #}
+                {% if not loop.last %}
+                    {# start row #}
+                    <div class="{{ settings.divisibleClass }}">
+                {% endif %}
+            {% endif %}
+            {% if loop.last %}
+                </div>{# end row #}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endblock %}


### PR DESCRIPTION
Together with symfony-cmf/BlockBundle#10 this gives more control on how a container block and its children blocks are rendered.

An example for the Sandbox would be:

```
{# SandboxMainBundle:Homepage:index.html.twig #}
{{ sonata_block_render({
    'name': 'additionalInfoBlock',
    'settings': {
        'divisibleBy': 3,
        'divisibleClass': 'row'
    }
}) }}
```
