### PR TITLE
[WIP] Add block options

### DIFF
--- a/Block/ActionBlockService.php
+++ b/Block/ActionBlockService.php
@@ -9,7 +9,7 @@ use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\AdminBundle\Validator\ErrorElement;
-use Sonata\BlockBundle\Block\BaseBlockService;
+use Symfony\Cmf\Bundle\BlockBundle\Block\BaseBlockService;
 
 class ActionBlockService extends BaseBlockService implements BlockServiceInterface
 {

--- a/Block/BaseBlockService.php
+++ b/Block/BaseBlockService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Block;
+
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Sonata\BlockBundle\Block\BlockServiceInterface;
+use Sonata\BlockBundle\Block\BaseBlockService as SonataBaseBlockService;
+
+abstract class BaseBlockService extends SonataBaseBlockService implements BlockServiceInterface
+{
+    /**
+     * Sets the default options for this block.
+     *
+     * @param OptionsResolverInterface $resolver The resolver for the options.
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'attr'     => array(),
+        ));
+
+        $resolver->setAllowedTypes(array(
+            'attr'     => 'array',
+        ));
+    }
+}

--- a/Block/ContainerBlockService.php
+++ b/Block/ContainerBlockService.php
@@ -5,11 +5,11 @@ namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Cmf\Bundle\BlockBundle\Document\ContainerBlock;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Cmf\Bundle\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\AdminBundle\Validator\ErrorElement;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockRendererInterface;
 
 class ContainerBlockService extends BaseBlockService implements BlockServiceInterface

--- a/Block/PHPCRBlockLoader.php
+++ b/Block/PHPCRBlockLoader.php
@@ -4,7 +4,10 @@ namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 
 use Sonata\BlockBundle\Block\BlockLoaderInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class PHPCRBlockLoader implements BlockLoaderInterface
 {
@@ -12,13 +15,32 @@ class PHPCRBlockLoader implements BlockLoaderInterface
     protected $documentManagerName;
 
     /**
+     * @var BlockServiceManagerInterface
+     */
+    private $blockServiceManager;
+
+    /**
+     * @var OptionsResolverInterface[]
+     */
+    private $optionsResolvers;
+
+    /**
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
      * @param string $documentManagerName
      */
-    public function __construct(ContainerInterface $container, $documentManagerName)
+    public function __construct(ContainerInterface $container, $documentManagerName, BlockServiceManagerInterface $blockServiceManager)
     {
         $this->container = $container;
         $this->dm = $this->container->get('doctrine_phpcr')->getManager($documentManagerName);
+        $this->blockServiceManager = $blockServiceManager;
+    }
+
+    /**
+     * @return \Sonata\BlockBundle\Block\BlockServiceManagerInterface
+     */
+    public function getBlockServiceManager()
+    {
+        return $this->blockServiceManager;
     }
 
     /**
@@ -28,12 +50,9 @@ class PHPCRBlockLoader implements BlockLoaderInterface
     {
         if ($this->support($configuration)) {
             $block = $this->findByName($configuration['name']);
+            unset($configuration['name']);
 
-            // merge settings
-            $block->setSettings(array_merge(
-                isset($configuration['settings']) && is_array($configuration['settings']) ? $configuration['settings'] : array(),
-                is_array($block->getSettings()) ? $block->getSettings() : array()
-            ));
+            $this->createResolvedBlock($block, $configuration);
 
             return $block;
         }
@@ -82,5 +101,56 @@ class PHPCRBlockLoader implements BlockLoaderInterface
     protected function isAbsolutePath($path)
     {
         return substr($path, 0, 1) == '/';
+    }
+
+    /**
+     * Returns the configured options resolver used for this block.
+     *
+     * @return \Symfony\Component\OptionsResolver\OptionsResolverInterface The options resolver.
+     */
+    public function getOptionsResolver(BlockInterface $block)
+    {
+        if (!isset($this->optionsResolvers[$block->getType()])) {
+            $this->optionsResolvers[$block->getType()] = new OptionsResolver();
+
+            $blockService = $this->getBlockServiceManager()->get($block);
+            $blockService->setDefaultOptions($this->optionsResolvers[$block->getType()]);
+        }
+
+        return $this->optionsResolvers[$block->getType()];
+    }
+
+    /**
+     * Resolves a block
+     *
+     * @param \Sonata\BlockBundle\Model\BlockInterface $block
+     * @param array $configuration
+     */
+    public function createResolvedBlock(BlockInterface $block, array $configuration = array())
+    {
+        $settings = isset($configuration['settings']) ? $configuration['settings'] : array();
+        $options = $configuration;
+        $childrenConfiguration = isset($configuration['children']) ? $configuration['children'] : array();
+        unset($options['settings']);
+        unset($options['children']);
+
+        // merge settings
+        $block->setSettings(array_merge(
+            $settings,
+            is_array($block->getSettings()) ? $block->getSettings() : array()
+        ));
+
+        // resolve options
+        $resolver = $this->getOptionsResolver($block);
+        $block->setOptions($resolver->resolve($options));
+
+        // resolve children
+        if ($block->hasChildren()) {
+            foreach ($block->getChildren() as $childBlock) {
+                $childConfiguration = isset($childrenConfiguration[$childBlock->getType()]) ? $childrenConfiguration[$childBlock->getType()] : array();
+
+                $this->createResolvedBlock($childBlock, $childConfiguration);
+            }
+        }
     }
 }

--- a/Block/ReferenceBlockService.php
+++ b/Block/ReferenceBlockService.php
@@ -8,7 +8,7 @@ use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\AdminBundle\Validator\ErrorElement;
-use Sonata\BlockBundle\Block\BaseBlockService;
+use Symfony\Cmf\Bundle\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockRendererInterface;
 
 class ReferenceBlockService extends BaseBlockService implements BlockServiceInterface

--- a/Block/SimpleBlockService.php
+++ b/Block/SimpleBlockService.php
@@ -3,11 +3,12 @@
 namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Cmf\Bundle\BlockBundle\Block\BaseBlockService;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\AdminBundle\Validator\ErrorElement;
-use Sonata\BlockBundle\Block\BaseBlockService;
 
 class SimpleBlockService extends BaseBlockService implements BlockServiceInterface
 {
@@ -45,7 +46,7 @@ class SimpleBlockService extends BaseBlockService implements BlockServiceInterfa
         }
 
         if ($block->getEnabled()) {
-            $response = $this->renderResponse($this->template, array('block' => $block), $response);
+            $response = $this->renderResponse($block->getOption('template'), array('block' => $block), $response);
         }
 
         return $response;
@@ -121,5 +122,16 @@ class SimpleBlockService extends BaseBlockService implements BlockServiceInterfa
     public function setTemplate($template)
     {
         $this->template = $template;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+        $resolver->replaceDefaults(array(
+            'template' => $this->template
+        ));
     }
 }

--- a/Document/BaseBlock.php
+++ b/Document/BaseBlock.php
@@ -34,6 +34,8 @@ abstract class BaseBlock implements BlockInterface
     /** @PHPCRODM\String(assoc="") */
     protected $settings = array();
 
+    protected $options = array();
+
     /**
      * @param string $src
      */
@@ -327,6 +329,36 @@ abstract class BaseBlock implements BlockInterface
     public function getSetting($name, $default = null)
     {
         return isset($this->settings[$name]) ? $this->settings[$name] : $default;
+    }
+
+    /**
+     * Get options
+     *
+     * @return array $options
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Set options
+     *
+     * @param array $options
+     */
+    public function setOptions(array $options = array())
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @param $name
+     * @param null $default
+     * @return null
+     */
+    public function getOption($name, $default = null)
+    {
+        return isset($this->options[$name]) ? $this->options[$name] : $default;
     }
 
     /**

--- a/Document/ContainerBlock.php
+++ b/Document/ContainerBlock.php
@@ -29,4 +29,9 @@ class ContainerBlock extends BaseBlock
     {
         return $this->children = $children;
     }
+
+    public function hasChildren()
+    {
+        return $this->children ? !$this->getChildren()->isEmpty() : false;
+    }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,6 +10,7 @@
             <tag name="sonata.block.loader" />
             <argument type="service" id="service_container" />
             <argument />
+            <argument type="service" id="sonata.block.manager" />
         </service>
 
         <service id="symfony_cmf.block.simple" class="Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService">


### PR DESCRIPTION
This PR adds the feature to overide options like the template. See https://groups.google.com/forum/?fromgroups=#!topic/symfony-cmf-devs/_t0jQCsdEcU I think this could be a solution, it works without BC breaks on the BlockInterface. It is probably far from good, but this will give an idea and could start discussion.

It allows to do things like this in the template:

```
    {{ sonata_block_render({
        'name': 'additionalInfoBlock',
        'template': 'SandboxMainBundle:Block:overloaded_container_block.html.twig',
        'attr': {
            'class': 'additional-info-block'
        },
        'settings': {
            'divisibleBy': 3,
            'divisibleClass': 'row-fluid',
            'childClass': 'span4'
        },
        'children': {
            'symfony_cmf.block.simple': {
                'template': 'SandboxMainBundle:Block:overloaded_block_simple.html.twig',
                'attr': {
                    'class': 'simple-block'
                }
            }
        }
    }) }}
```

Furthermore configuration for a block is split in:
- settings: fe. a url for a feed, this configuration could be changed through a UI
- options: configuration to be used in templates etc. but not changed through a UI
