### PR TITLE
More flexibility for simple block service

### DIFF
--- a/Block/SimpleBlockService.php
+++ b/Block/SimpleBlockService.php
@@ -11,7 +11,15 @@ use Sonata\BlockBundle\Block\BaseBlockService;
 
 class SimpleBlockService extends BaseBlockService implements BlockServiceInterface
 {
-    private $template = 'SymfonyCmfBlockBundle:Block:block_simple.html.twig';
+    protected $template = 'SymfonyCmfBlockBundle:Block:block_simple.html.twig';
+
+    public function __construct($name, $templating, $template = null)
+    {
+        if ($template) {
+            $this->template = $template;
+        }
+        parent::__construct($name, $templating);
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This PR lets:
- An extending BlockService override the default template
- A user inject a custom template (Twig template overriding is not enough since one might need different templates for different blocks that are executed by the SimpleBlockService)
