### PR TITLE
Cache: add varnish version and purgeinstruction

### DIFF
--- a/Cache/BlockVarnishCache.php
+++ b/Cache/BlockVarnishCache.php
@@ -17,19 +17,29 @@ use Sonata\CacheBundle\Adapter\VarnishCache;
  */
 class BlockVarnishCache extends VarnishCache
 {
+    /**
+     * @var BlockRendererInterface
+     */
     protected $blockRenderer;
+
+    /**
+     * @var BlockLoaderInterface
+     */
     protected $blockLoader;
 
     /**
-     * @param string $token
-     * @param \Symfony\Component\Routing\RouterInterface $router
-     * @param \Sonata\BlockBundle\Block\BlockRendererInterface $blockRenderer
-     * @param \Sonata\BlockBundle\Block\BlockLoaderInterface $blockLoader
-     * @param array $servers
+     * Constructor
+     *
+     * @param string                 $token            A token
+     * @param RouterInterface        $router           A router instance
+     * @param BlockRendererInterface $blockRenderer    A block renderer instance
+     * @param BlockLoaderInterface   $blockLoader      A block loader instance
+     * @param array                  $servers          An array of servers
+     * @param string                 $purgeInstruction The purge instruction (purge in Varnish 2, ban in Varnish 3)
      */
-    public function __construct($token, RouterInterface $router, BlockRendererInterface $blockRenderer, BlockLoaderInterface $blockLoader, array $servers = array())
+    public function __construct($token, RouterInterface $router, BlockRendererInterface $blockRenderer, BlockLoaderInterface $blockLoader, array $servers = array(), $purgeInstruction)
     {
-        parent::__construct($token, $servers, $router, null);
+        parent::__construct($token, $servers, $router, $purgeInstruction, null);
 
         $this->blockRenderer = $blockRenderer;
         $this->blockLoader   = $blockLoader;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -78,6 +78,7 @@ class Configuration implements ConfigurationInterface
                             ->fixXmlConfig('server')
                             ->children()
                                 ->scalarNode('token')->defaultValue(hash('sha256', uniqid(mt_rand(), true)))->end()
+                                ->scalarNode('version')->defaultValue(2)->end()
                                 ->arrayNode('servers')
                                     ->prototype('scalar')->end()
                                 ->end()

--- a/DependencyInjection/SymfonyCmfBlockExtension.php
+++ b/DependencyInjection/SymfonyCmfBlockExtension.php
@@ -123,6 +123,7 @@ class SymfonyCmfBlockExtension extends Extension
                 ->getDefinition('symfony_cmf.block.cache.varnish')
                 ->replaceArgument(0, $config['caches']['varnish']['token'])
                 ->replaceArgument(4, $config['caches']['varnish']['servers'])
+                ->replaceArgument(5, 3 === $config['caches']['varnish']['version'] ? 'ban' : 'purge');
             ;
         } else {
             $container->removeDefinition('symfony_cmf.block.cache.varnish');

--- a/Resources/config/cache.xml
+++ b/Resources/config/cache.xml
@@ -14,6 +14,7 @@
             <argument type="service" id="sonata.block.renderer" />
             <argument type="service" id="sonata.block.loader.chain" />
             <argument type="collection" />
+            <argument />
         </service>
 
         <service id="symfony_cmf.block.cache.ssi" class="Symfony\Cmf\Bundle\BlockBundle\Cache\BlockSsiCache">

--- a/Tests/Cache/BlockVarnishCacheTest.php
+++ b/Tests/Cache/BlockVarnishCacheTest.php
@@ -18,7 +18,7 @@ class BlockVarnishCacheTest extends \PHPUnit_Framework_TestCase
 
         $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
 
-        $cache = new BlockVarnishCache('My Token', $router, $blockRenderer, $blockLoader, array());
+        $cache = new BlockVarnishCache('My Token', $router, $blockRenderer, $blockLoader, array(), 'ban');
 
         $cache->get($keys, 'data');
     }
@@ -41,7 +41,7 @@ class BlockVarnishCacheTest extends \PHPUnit_Framework_TestCase
 
         $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
 
-        $cache = new BlockVarnishCache('My Token', $router, $blockRenderer, $blockLoader, array());
+        $cache = new BlockVarnishCache('My Token', $router, $blockRenderer, $blockLoader, array(), 'ban');
 
         $this->assertTrue($cache->flush(array()));
         $this->assertTrue($cache->flushAll());
@@ -81,7 +81,7 @@ class BlockVarnishCacheTest extends \PHPUnit_Framework_TestCase
 
         $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
 
-        $cache = new BlockVarnishCache($token, $router, $blockRenderer, $blockLoader, array());
+        $cache = new BlockVarnishCache($token, $router, $blockRenderer, $blockLoader, array(), 'ban');
 
         $request = new \Symfony\Component\HttpFoundation\Request($keys, array(), array('_token' => 'XXX'));
 
@@ -105,7 +105,7 @@ class BlockVarnishCacheTest extends \PHPUnit_Framework_TestCase
 
         $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
 
-        $cache = new BlockVarnishCache($token, $router, $blockRenderer, $blockLoader, array());
+        $cache = new BlockVarnishCache($token, $router, $blockRenderer, $blockLoader, array(), 'ban');
 
         $refCache = new \ReflectionClass($cache);
         $refComputeHash = $refCache->getMethod('computeHash');


### PR DESCRIPTION
To be in sync with https://github.com/sonata-project/SonataCacheBundle/blob/master/Adapter/VarnishCache.php

The purgeInstruction based on the varnish version was added.
