### PR TITLE
Cache - remember BlockContext for Varnish, Ssi and Js

### DIFF
--- a/Cache/BlockJsCache.php
+++ b/Cache/BlockJsCache.php
@@ -29,8 +29,13 @@ class BlockJsCache implements CacheInterface
      * @param BlockContextManagerInterface $blockContextManager
      * @param bool $sync
      */
-    public function __construct(RouterInterface $router, BlockRendererInterface $blockRenderer, BlockLoaderInterface $blockLoader, BlockContextManagerInterface $blockContextManager, $sync = false)
-    {
+    public function __construct(
+        RouterInterface $router,
+        BlockRendererInterface $blockRenderer,
+        BlockLoaderInterface $blockLoader,
+        BlockContextManagerInterface $blockContextManager,
+        $sync = false
+    ) {
         $this->router              = $router;
         $this->blockRenderer       = $blockRenderer;
         $this->blockLoader         = $blockLoader;
@@ -188,7 +193,18 @@ CONTENT
             return new Response('', 404);
         }
 
-        $response = $this->blockRenderer->render($this->blockContextManager->get($block));
+        $settings = $request->get(BlockContextManagerInterface::CACHE_KEY, array());
+
+        if (!is_array($settings)) {
+            throw new \RuntimeException(sprintf(
+                'Query string parameter `%s` is not an array',
+                BlockContextManagerInterface::CACHE_KEY
+            ));
+        }
+
+        $response = $this->blockRenderer->render(
+            $this->blockContextManager->get($block, $settings)
+        );
         $response->setPrivate(); //  always set to private
 
         if ($this->sync) {

--- a/Cache/BlockSsiCache.php
+++ b/Cache/BlockSsiCache.php
@@ -29,8 +29,13 @@ class BlockSsiCache extends SsiCache
      * @param BlockLoaderInterface $blockLoader
      * @param BlockContextManagerInterface $blockContextManager
      */
-    public function __construct($token, RouterInterface $router, BlockRendererInterface $blockRenderer, BlockLoaderInterface $blockLoader, BlockContextManagerInterface $blockContextManager)
-    {
+    public function __construct(
+        $token,
+        RouterInterface $router,
+        BlockRendererInterface $blockRenderer,
+        BlockLoaderInterface $blockLoader,
+        BlockContextManagerInterface $blockContextManager
+    ) {
         parent::__construct($token, $router, null);
 
         $this->blockRenderer       = $blockRenderer;
@@ -114,6 +119,17 @@ class BlockSsiCache extends SsiCache
             throw new NotFoundHttpException(sprintf('Block not found : %s', $request->get('block_id')));
         }
 
-        return $this->blockRenderer->render($this->blockContextManager->get($block));
+        $settings = $request->get(BlockContextManagerInterface::CACHE_KEY, array());
+
+        if (!is_array($settings)) {
+            throw new \RuntimeException(sprintf(
+                'Query string parameter `%s` is not an array',
+                BlockContextManagerInterface::CACHE_KEY
+            ));
+        }
+
+        return $this->blockRenderer->render(
+            $this->blockContextManager->get($block, $settings)
+        );
     }
 }

--- a/Cache/BlockVarnishCache.php
+++ b/Cache/BlockVarnishCache.php
@@ -44,8 +44,15 @@ class BlockVarnishCache extends VarnishCache
      * @param array                         $servers                An array of servers
      * @param string                        $purgeInstruction       The purge instruction (purge in Varnish 2, ban in Varnish 3)
      */
-    public function __construct($token, RouterInterface $router, BlockRendererInterface $blockRenderer, BlockLoaderInterface $blockLoader, BlockContextManagerInterface $blockContextManager, array $servers = array(), $purgeInstruction)
-    {
+    public function __construct(
+        $token,
+        RouterInterface $router,
+        BlockRendererInterface $blockRenderer,
+        BlockLoaderInterface $blockLoader,
+        BlockContextManagerInterface $blockContextManager,
+        array $servers = array(),
+        $purgeInstruction
+    ) {
         parent::__construct($token, $servers, $router, $purgeInstruction, null);
 
         $this->blockRenderer       = $blockRenderer;
@@ -129,6 +136,17 @@ class BlockVarnishCache extends VarnishCache
             throw new NotFoundHttpException(sprintf('Block not found : %s', $request->get('block_id')));
         }
 
-        return $this->blockRenderer->render($this->blockContextManager->get($block));
+        $settings = $request->get(BlockContextManagerInterface::CACHE_KEY, array());
+
+        if (!is_array($settings)) {
+            throw new \RuntimeException(sprintf(
+                'Query string parameter `%s` is not an array',
+                BlockContextManagerInterface::CACHE_KEY
+            ));
+        }
+
+        return $this->blockRenderer->render(
+            $this->blockContextManager->get($block, $settings)
+        );
     }
 }

--- a/DependencyInjection/CmfBlockExtension.php
+++ b/DependencyInjection/CmfBlockExtension.php
@@ -1,12 +1,12 @@
 <?php
 namespace Symfony\Cmf\Bundle\BlockBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class CmfBlockExtension extends Extension implements PrependExtensionInterface
 {
@@ -148,8 +148,8 @@ class CmfBlockExtension extends Extension implements PrependExtensionInterface
             $container
                 ->getDefinition('cmf.block.cache.varnish')
                 ->replaceArgument(0, $config['caches']['varnish']['token'])
-                ->replaceArgument(4, $config['caches']['varnish']['servers'])
-                ->replaceArgument(5, 3 === $config['caches']['varnish']['version'] ? 'ban' : 'purge');
+                ->replaceArgument(5, $config['caches']['varnish']['servers'])
+                ->replaceArgument(6, 3 === $config['caches']['varnish']['version'] ? 'ban' : 'purge');
             ;
         } else {
             $container->removeDefinition('cmf.block.cache.varnish');


### PR DESCRIPTION
Depends on https://github.com/sonata-project/SonataBlockBundle/pull/77

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/pull/180 |

When using Varnish, Ssi or Js cache the settings passed here are lost:

```
{{ sonata_block_render({
    'name': 'rssBlock'
},{
    'maxItems': 2
}) }}
```

Taking Js as example, an url is generated and added to some javascript. This javascript is injected in the page. When the page is loaded, the javascript calls the url to retrieve the block content. By adding the settings passed to the BlockContextManager to the `extra_cache_keys` and then as query parameters to the url it is possible for the cache adapter to reconstruct the BlockContext.
