### PR TITLE
action block does a subrequest, we should not lose the locale

### DIFF
--- a/Block/ActionBlockService.php
+++ b/Block/ActionBlockService.php
@@ -9,6 +9,7 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Kernel;
@@ -16,6 +17,11 @@ use Symfony\Component\HttpKernel\Kernel;
 class ActionBlockService extends BaseBlockService implements BlockServiceInterface
 {
     protected $renderer;
+
+    /**
+     * @var Request
+     */
+    protected $request;
 
     /**
      * @param string $name
@@ -26,6 +32,14 @@ class ActionBlockService extends BaseBlockService implements BlockServiceInterfa
     {
         parent::__construct($name, $templating);
         $this->renderer = $renderer;
+    }
+
+    /**
+     * @param Request $request
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
     }
 
     /**
@@ -62,10 +76,12 @@ class ActionBlockService extends BaseBlockService implements BlockServiceInterfa
             ));
         }
 
+        $locale = $this->request ? $this->request->getLocale() : null;
+
         if ($block->getEnabled()) {
             $response = new Response($this->renderer->render(new ControllerReference(
                 $block->getActionName(),
-                array('block' => $block, 'blockContext' => $blockContext)
+                array('block' => $block, 'blockContext' => $blockContext, '_locale' => $locale)
             )));
         }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -48,6 +48,7 @@
 
         <service id="cmf.block.action" class="Symfony\Cmf\Bundle\BlockBundle\Block\ActionBlockService">
             <tag name="sonata.block" />
+            <tag name="cmf_request_aware"/>
             <argument>cmf.block.action</argument>
             <argument type="service" id="templating" />
             <argument type="service" id="fragment.handler" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

the locale is something that happens outside of the block configuration or blockContext.

we don't depend on core bundle yet, but when we add publish workflow to blocks we will. and the code will survive without core, just not pass the locale on as we don't get the request injected without the compiler pass for cmf.request_aware.
