### PR TITLE
Update CmfBlockExtension initRuntime() typehint

### DIFF
--- a/Twig/Extension/CmfBlockExtension.php
+++ b/Twig/Extension/CmfBlockExtension.php
@@ -32,7 +32,7 @@ class CmfBlockExtension extends CmfBlockHelper implements \Twig_ExtensionInterfa
      *
      * @param Twig_Environment $environment The current Twig_Environment instance
      */
-    public function initRuntime(Twig_Environment $environment)
+    public function initRuntime(\Twig_Environment $environment)
     {
     }
 


### PR DESCRIPTION
@dbu Without this change, the following error can occur in s Symfony Standard Edition project:

Catchable Fatal Error: Argument 1 passed to Symfony\Cmf\Bundle\BlockBundle\Twig\Extension\CmfBlockExtension::initRuntime() must be an instance of Symfony\Cmf\Bundle\BlockBundle\Twig\Extension\Twig_Environment, instance of Twig_Environment given
