### PR TITLE
Add admin extension to edit base fields of base block document

### DIFF
--- a/Admin/BaseAdminExtension.php
+++ b/Admin/BaseAdminExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Admin;
+
+use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Form\FormMapper;
+
+/**
+ * Class BaseAdminExtension
+ * @package Symfony\Cmf\Bundle\BlockBundle\Admin
+ * @author Sven Cludius<sven.cludius@valiton.com>
+ */
+class BaseAdminExtension extends AdminExtension {
+
+    /**
+     * Configure form fields
+     *
+     * @param FormMapper $formMapper
+     */
+    public function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_base')
+                ->add('enabled', 'checkbox')
+                ->add('ttl', 'text')
+            ->end()
+        ;
+    }
+
+}

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -25,5 +25,8 @@
             </call>
         </service>
 
+        <service id="cmf.block.admin.base.extension" class="Symfony\Cmf\Bundle\BlockBundle\Admin\BaseAdminExtension" >
+        </service>
+
     </services>
 </container>

--- a/Resources/translations/CmfBlockBundle.de.yml
+++ b/Resources/translations/CmfBlockBundle.de.yml
@@ -75,3 +75,6 @@ form:
     label_position: Position
     label_link_url: Link URL
     label_image: Bild
+    group_base: Erweitert
+    label_enabled: Aktiviert
+    label_ttl: Cache-TTL

--- a/Resources/translations/CmfBlockBundle.en.yml
+++ b/Resources/translations/CmfBlockBundle.en.yml
@@ -75,3 +75,6 @@ form:
     label_position: Position
     label_link_url: Link URL
     label_image: Image
+    group_base: Advanced
+    label_enabled: Enabled
+    label_ttl: Cache-TTL

--- a/Resources/translations/CmfBlockBundle.fr.yml
+++ b/Resources/translations/CmfBlockBundle.fr.yml
@@ -74,3 +74,6 @@ form:
     label_position: Position
     label_link_url: URL Lien
     label_image: Image
+    group_base: Avancé
+    label_enabled: Activer
+    label_ttl: Cache-TTL


### PR DESCRIPTION
Pull request for issue #28 make cache related meta data editable in the admin

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #28 |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/pull/172 |
