### PR TITLE
Update services.xml

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -73,7 +73,7 @@
         </service>
 
         <service id="cmf_block.twig.embed_extension" class="%cmf_block.twig_extension_class%">
-            <argument type="service" id="sonata.block.twig.extension"/>
+            <argument type="service" id="sonata.block.templating.helper" />
             <argument>%cmf_block.twig.cmf_embed_blocks.prefix%</argument>
             <argument>%cmf_block.twig.cmf_embed_blocks.postfix%</argument>
             <argument type="service" id="logger"/>
@@ -81,7 +81,7 @@
         </service>
 
         <service id="cmf_block.templating.helper.block" class="%cmf_block.templating.helper.block.class%">
-            <argument type="service" id="sonata.block.twig.extension" />
+            <argument type="service" id="sonata.block.templating.helper" />
             <argument>%cmf_block.twig.cmf_embed_blocks.prefix%</argument>
             <argument>%cmf_block.twig.cmf_embed_blocks.postfix%</argument>
             <argument type="service" id="logger" />


### PR DESCRIPTION
This updates the service used for the first constructor argument in services which use the CmfBlockHelper.

Catchable Fatal Error: Argument 1 passed to Symfony\Cmf\Bundle\BlockBundle\Templating\Helper\CmfBlockHelper::__construct() must be an instance of Sonata\BlockBundle\Templating\Helper\BlockHelper, instance of Sonata\BlockBundle\Twig\Extension\BlockExtension given, called in app/cache/test/appTestDebugProjectContainer.php on line 1199 and defined in vendor/symfony-cmf/block-bundle/Symfony/Cmf/Bundle/BlockBundle/Templating/Helper/CmfBlockHelper.php line 32

ping @dbu
