### PR TITLE
Update CmfBlockHelper.php to work with CmfBlockExtension and sonata_bloc...

### DIFF
--- a/Templating/Helper/CmfBlockHelper.php
+++ b/Templating/Helper/CmfBlockHelper.php
@@ -54,17 +54,23 @@ class CmfBlockHelper extends Helper
     /**
      * Executes the block as specified in the content.
      *
-     * @param array $block An array including the block name
+     * @param mixed $block An array including the block name from embedBlocks()
+     * @param array $options
      *
      * @return string the rendered block
      */
-    public function render($block)
+    public function render($block, array $options = array())
     {
+        if (is_array($block) && !isset($block['name']) && isset($block[1])) {
+            // received data from embedBlocks()
+            $block = array('name' => $block[1]);
+        }
+
         try {
-            return $this->sonataBlock->render(array('name' => $block[1]));
+            return $this->sonataBlock->render($block, $options);
         } catch (BlockNotFoundException $e) {
             if ($this->logger) {
-                $this->logger->warn('Failed to render block "' . $block[1] . '" embedded in content: ' . $e->getTraceAsString());
+                $this->logger->warn('Failed to render block' . (is_array($block) && isset($block['name']) ? ' "' . $block['name'] . '"' : '') . ' embedded in content: ' . $e->getTraceAsString());
             }
         }
         return '';


### PR DESCRIPTION
...k_render

The CmfBlockExtension extends the Sonata\BlockBundle\Twig\Extension\BlockExtension which defines `sonata_block_render` in its (extended) getFunctions() method.  The `sonata_block_render` simple Twig function will call the CmfBlockHelper render() method, so it should be more like the Sonata\BlockBundle\Templating\Helper\BlockHelper render() method.

An exception has been thrown during the rendering of a template ("Notice: Undefined offset: 1 in /vendor/symfony-cmf/block-bundle/Symfony/Cmf/Bundle/BlockBundle/Templating/Helper/CmfBlockHelper.php line 64")

The template code that triggered this error was similar to:

``` jinja
{{ sonata_block_render({ 'name': '/blocks/Test/case' }, { 'template': 'ExampleBundle:Test:Block/block_simple.html.twig' }) }}
```

ping @dbu
