### PR TITLE
Update CmfBlockExtension to prevent overriding sonata_block_render

### DIFF
--- a/Twig/Extension/CmfBlockExtension.php
+++ b/Twig/Extension/CmfBlockExtension.php
@@ -4,15 +4,15 @@ namespace Symfony\Cmf\Bundle\BlockBundle\Twig\Extension;
 
 use Symfony\Cmf\Bundle\BlockBundle\Templating\Helper\CmfBlockHelper;
 
-use Sonata\BlockBundle\Twig\Extension\BlockExtension as SonataBlockExtension;
-
 /**
  * Utility function for blocks
  *
  * @author David Buchmann <david@liip.ch>
  */
-class CmfBlockExtension extends SonataBlockExtension
+class CmfBlockExtension extends \Twig_Extension
 {
+    protected $blockHelper;
+
     public function __construct(CmfBlockHelper $blockHelper)
     {
         $this->blockHelper = $blockHelper;


### PR DESCRIPTION
An exception has been thrown during the rendering of a template ("Notice: Undefined offset: 1 in /vendor/symfony-cmf/block-bundle/Symfony/Cmf/Bundle/BlockBundle/Templating/Helper/CmfBlockHelper.php line 64")

The template code that triggered this error was similar to:

``` jinja
{{ sonata_block_render({ 'name': '/blocks/Test/case' }, { 'template': 'ExampleBundle:Test:Block/block_simple.html.twig' }) }}
```

The issue appears when the `new Sonata\BlockBundle\SonataBlockBundle(),` is before the `new Symfony\Cmf\Bundle\BlockBundle\CmfBlockBundle(),` in a Symfony2 Standard Edition app/AppKernel.php registerBundles() method.
