### PR TITLE
make remaining service config consistent

### DIFF
--- a/DependencyInjection/CmfBlockExtension.php
+++ b/DependencyInjection/CmfBlockExtension.php
@@ -63,7 +63,7 @@ class CmfBlockExtension extends Extension implements PrependExtensionInterface
                 $this->loadSonataAdmin($config['multilang'], $loader, $container, false, 'multilang.');
             }
             if (isset($config['multilang']['simple_document_class'])) {
-                $container->setParameter($this->getAlias() . '.multilang.document_class', $config['multilang']['simple_document_class']);
+                $container->setParameter($this->getAlias() . '.multilang.document.class', $config['multilang']['simple_document_class']);
             }
 
             $container->setParameter($this->getAlias() . '.multilang.locales', $config['multilang']['locales']);
@@ -135,7 +135,7 @@ class CmfBlockExtension extends Extension implements PrependExtensionInterface
         $loader->load('admin.xml');
 
         if (isset($config['simple_admin_class'])) {
-            $container->setParameter($this->getAlias() . '.' . $prefix . 'simple_admin_class', $config['simple_admin.class']);
+            $container->setParameter($this->getAlias() . '.' . $prefix . 'simple_admin.class', $config['simple_admin.class']);
         }
 
         if ($useImagine) {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,8 +5,8 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="cmf_block.rss_controller_class">Symfony\Cmf\Bundle\BlockBundle\Controller\RssController</parameter>
-        <parameter key="cmf_block.twig_extension_class">Symfony\Cmf\Bundle\BlockBundle\Twig\Extension\CmfBlockExtension</parameter>
+        <parameter key="cmf_block.rss_controller.class">Symfony\Cmf\Bundle\BlockBundle\Controller\RssController</parameter>
+        <parameter key="cmf_block.twig_extension.class">Symfony\Cmf\Bundle\BlockBundle\Twig\Extension\CmfBlockExtension</parameter>
         <parameter key="cmf_block.templating.helper.block.class">Symfony\Cmf\Bundle\BlockBundle\Templating\Helper\CmfBlockHelper</parameter>
         <parameter key="cmf_block.fragment.renderer.action.class">Symfony\Cmf\Bundle\BlockBundle\Fragment\ActionFragmentRenderer</parameter>
         <parameter key="cmf_block.fragment.path">/_cmf_block_fragment</parameter>
@@ -58,13 +58,13 @@
             <argument>CmfBlockBundle:Block:block_slideshow.html.twig</argument>
         </service>
 
-        <service id="cmf.block.rss_controller" class="%cmf_block.rss_controller_class%" >
+        <service id="cmf.block.rss_controller" class="%cmf_block.rss_controller.class%" >
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>
         </service>
 
-        <service id="cmf_block.twig.embed_extension" class="%cmf_block.twig_extension_class%">
+        <service id="cmf_block.twig.embed_extension" class="%cmf_block.twig_extension.class%">
             <argument type="service" id="cmf_block.templating.helper.block"/>
             <tag name="twig.extension"/>
         </service>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | minimal |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #78 |
| License | MIT |
| Doc PR | - |

A few _class slipped through, and there was some confusion in the DI extension that would lead to some class name configuration getting lost.
