### PR TITLE
Added base pattern / name to admin classes

### DIFF
--- a/Admin/ActionBlockAdmin.php
+++ b/Admin/ActionBlockAdmin.php
@@ -12,6 +12,9 @@ use Symfony\Cmf\Bundle\BlockBundle\Admin\AbstractBlockAdmin;
  */
 class ActionBlockAdmin extends AbstractBlockAdmin
 {
+    protected $baseRouteName = 'cmf_block_action';
+    protected $baseRoutePattern = '/cmf/block/action';
+
     /**
      * {@inheritdoc}
      */

--- a/Admin/ContainerBlockAdmin.php
+++ b/Admin/ContainerBlockAdmin.php
@@ -12,6 +12,9 @@ use Symfony\Cmf\Bundle\BlockBundle\Admin\AbstractBlockAdmin;
  */
 class ContainerBlockAdmin extends AbstractBlockAdmin
 {
+    protected $baseRouteName = 'cmf_block_container';
+    protected $baseRoutePattern = '/cmf/block/container';
+
     /**
      * {@inheritdoc}
      */

--- a/Admin/MultilangSimpleBlockAdmin.php
+++ b/Admin/MultilangSimpleBlockAdmin.php
@@ -11,6 +11,9 @@ use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\MultilangSimpleBlock;
  */
 class MultilangSimpleBlockAdmin extends SimpleBlockAdmin
 {
+    protected $baseRouteName = 'cmf_block_multilangsimpleblock';
+    protected $baseRoutePattern = '/cmf/block/multilangsimpleblock';
+
     /**
      * @var array
      */

--- a/Admin/ReferenceBlockAdmin.php
+++ b/Admin/ReferenceBlockAdmin.php
@@ -12,6 +12,9 @@ use Symfony\Cmf\Bundle\BlockBundle\Admin\AbstractBlockAdmin;
  */
 class ReferenceBlockAdmin extends AbstractBlockAdmin
 {
+    protected $baseRouteName = 'cmf_block_reference';
+    protected $baseRoutePattern = '/cmf/block/reference';
+
     /**
      * {@inheritdoc}
      */

--- a/Admin/SimpleBlockAdmin.php
+++ b/Admin/SimpleBlockAdmin.php
@@ -12,6 +12,9 @@ use Symfony\Cmf\Bundle\BlockBundle\Admin\AbstractBlockAdmin;
  */
 class SimpleBlockAdmin extends AbstractBlockAdmin
 {
+    protected $baseRouteName = 'cmf_block_simple';
+    protected $baseRoutePattern = '/cmf/block/simple';
+
     /**
      * {@inheritdoc}
      */

--- a/Admin/StringBlockAdmin.php
+++ b/Admin/StringBlockAdmin.php
@@ -12,6 +12,9 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
  */
 class StringBlockAdmin extends AbstractBlockAdmin
 {
+    protected $baseRouteName = 'cmf_block_string';
+    protected $baseRoutePattern = '/cmf/block/string';
+
     /**
      * {@inheritdoc}
      */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* **2013-08-08**: [Admin] Added explicit base route name / patterns to fix broken schema. `cmf_bundle_action` becomes `cmf_block_action`.
 * **2013-08-01**: [DependencyInjection] moved phpcr specific configuration under ``persistence.phpcr`` and added ``enabled`` flag.
 * **2013-08-01**: [Model] Updated content to body property for ``SimpleBlock``, ``MultilangSimpleBlock`` and ``StringBlock``.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | ? |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

This fixes the sonata admin URLs in accordance with what we do in other bundles now.
