### PR TITLE
Add baseRoute*-parameters to new admin classes

### DIFF
--- a/Admin/Imagine/ImagineBlockAdmin.php
+++ b/Admin/Imagine/ImagineBlockAdmin.php
@@ -10,6 +10,9 @@ use Sonata\AdminBundle\Form\FormMapper;
  */
 class ImagineBlockAdmin extends AbstractBlockAdmin
 {
+    protected $baseRouteName = 'cmf_block_imagine';
+    protected $baseRoutePattern = '/cmf/block/imagine';
+
     /**
      * {@inheritdoc}
      */

--- a/Admin/Imagine/SlideshowBlockAdmin.php
+++ b/Admin/Imagine/SlideshowBlockAdmin.php
@@ -11,6 +11,9 @@ use Symfony\Cmf\Bundle\BlockBundle\Admin\AbstractBlockAdmin;
  */
 class SlideshowBlockAdmin extends AbstractBlockAdmin
 {
+    protected $baseRouteName = 'cmf_block_slideshow';
+    protected $baseRoutePattern = '/cmf/block/slideshow';
+
     /**
      * Path to where new slideshow blocks may be attached
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

With the latest `1.0.0-RC1` I see an exception

```
FileLoaderLoadException: Cannot import resource ".../app/config/." from ".../app/config/routing.yml". (Please define a default `baseRouteName` value for the admin class `Symfony\Cmf\Bundle\BlockBundle\Admin\Imagine\SlideshowBlockAdmin`)
```

I am a little bit confused, that this happens, because I thought SonataAdmin would set appropiate values for `$baseRouteName` and `$baseRoutePattern` itself, when they are missing. Unfortunately it seems, that this issue makes the BlockBundle unusable out of the box, when `LiipImagineBundle` exists [1]

However, I realized, that the other `Admin`-class in the BlockBundle has set this properties too and this PR add them for the both new `Admin`-class `SlideshowBlockAdmin` and `ImagineBlockBundle`.

[1] https://github.com/symfony-cmf/BlockBundle/blob/master/DependencyInjection/CmfBlockExtension.php#L52
