### PR TITLE
Fix detect bundles in configuration - fixes #121

### DIFF
--- a/DependencyInjection/CmfBlockExtension.php
+++ b/DependencyInjection/CmfBlockExtension.php
@@ -48,7 +48,8 @@ class CmfBlockExtension extends Extension implements PrependExtensionInterface
         $container->setParameter($this->getAlias() . '.twig.cmf_embed_blocks.postfix', $config['twig']['cmf_embed_blocks']['postfix']);
 
         // detect bundles
-        if ($config['use_imagine'] ||
+        $bundles = $container->getParameter('kernel.bundles');
+        if (true === $config['use_imagine'] ||
             ('auto' === $config['use_imagine'] && isset($bundles['LiipImagineBundle']))
         ) {
             $useImagine = true;


### PR DESCRIPTION
As spotted by @wcluijt the bundles are not detected correctly.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #121 |
| License | MIT |
| Doc PR | N/A |
