### PR TITLE
ImagineBlock - updated setImage typehint - fixes #123

### DIFF
--- a/Doctrine/Phpcr/ImagineBlock.php
+++ b/Doctrine/Phpcr/ImagineBlock.php
@@ -4,6 +4,7 @@ namespace Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr;
 
 use Symfony\Cmf\Bundle\MediaBundle\Doctrine\Phpcr\Image;
 use Symfony\Cmf\Bundle\MediaBundle\ImageInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * Block to hold an image
@@ -115,13 +116,24 @@ class ImagineBlock extends AbstractBlock
      * the document manager. Note that this block does not make much sense
      * without an image, though.
      *
-     * @param ImageInterface $image optional the image to update
+     * @param ImageInterface|UploadedFile|null $image optional the image to update
      */
-    public function setImage(ImageInterface $image = null)
+    public function setImage($image = null)
     {
-        if (!$image) {
+        if (! $image) {
             return;
-        } elseif ($this->image) {
+        }
+
+        if (! $image instanceof ImageInterface && ! $image instanceof UploadedFile) {
+            $type = is_object($image) ? get_class($image) : gettype($image);
+            throw new \InvalidArgumentException(sprintf(
+                'Image is not a valid type, "%s" given.',
+                $type
+            ));
+        }
+
+        if ($this->image) {
+            // existing image, only update content
             // TODO: https://github.com/doctrine/phpcr-odm/pull/262
             $this->image->copyContentFromFile($image);
         } elseif ($image instanceof ImageInterface) {

--- a/Resources/config/doctrine-phpcr/ImagineBlock.phpcr.xml
+++ b/Resources/config/doctrine-phpcr/ImagineBlock.phpcr.xml
@@ -17,7 +17,7 @@
 
         <field name="label" type="string" translated="true"/>
         <field name="linkUrl" type="string" translated="true"/>
-        <field name="filter" type="string"/>
+        <field name="filter" type="string" nullable="true"/>
 
         <child name="image" node-name="image">
             <cascade>


### PR DESCRIPTION
Spotted by @wcluijt in https://github.com/symfony-cmf/BlockBundle/issues/123.

This PR solves 2 bugs:
- If the mediabundle is not used the typehint causes an error when doctrine generates the proxies;
- The typehint is also not correct as either an Uploaded file or ImageInterface can be set.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #123 |
| License | MIT |
| Doc PR | N/A |
