### PR TITLE
use the root path provided by the base admin

### DIFF
--- a/Admin/AbstractBlockAdmin.php
+++ b/Admin/AbstractBlockAdmin.php
@@ -15,21 +15,6 @@ abstract class AbstractBlockAdmin extends Admin
     protected $translationDomain = 'CmfBlockBundle';
 
     /**
-     * Root path for the route content selection
-     *
-     * @var string
-     */
-    protected $contentRoot;
-
-    /**
-     * @param $contentRoot
-     */
-    public function setContentRoot($contentRoot)
-    {
-        $this->contentRoot = $contentRoot;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getExportFormats()

--- a/Admin/ActionBlockAdmin.php
+++ b/Admin/ActionBlockAdmin.php
@@ -34,7 +34,7 @@ class ActionBlockAdmin extends AbstractBlockAdmin
     {
         $formMapper
             ->with('form.group_general')
-            ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->contentRoot, 'choice_list' => array(), 'select_root_node' => true))
+            ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
             ->add('name', 'text')
             ->add('actionName', 'text')
             ->end()

--- a/Admin/ContainerBlockAdmin.php
+++ b/Admin/ContainerBlockAdmin.php
@@ -33,7 +33,7 @@ class ContainerBlockAdmin extends AbstractBlockAdmin
     {
         $formMapper
             ->with('form.group_general')
-                ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->contentRoot, 'choice_list' => array(), 'select_root_node' => true))
+                ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
                 ->add('name', 'text')
             ->end()
         ;

--- a/Admin/Imagine/ImagineBlockAdmin.php
+++ b/Admin/Imagine/ImagineBlockAdmin.php
@@ -30,7 +30,7 @@ class ImagineBlockAdmin extends AbstractBlockAdmin
                 ->add(
                     'parent',
                     'doctrine_phpcr_odm_tree',
-                    array('root_node' => $this->getRoot(), 'choice_list' => array(), 'select_root_node' => true)
+                    array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true)
                 )
                 ->add('name', 'text')
             ->end();

--- a/Admin/Imagine/SlideshowBlockAdmin.php
+++ b/Admin/Imagine/SlideshowBlockAdmin.php
@@ -15,26 +15,11 @@ class SlideshowBlockAdmin extends AbstractBlockAdmin
     protected $baseRoutePattern = '/cmf/block/slideshow';
 
     /**
-     * Path to where new slideshow blocks may be attached
-     *
-     * @var string
-     */
-    protected $blockRoot;
-
-    /**
      * Service name of the sonata_type_collection service to embed
      *
      * @var string
      */
     protected $embeddedAdminCode;
-
-    /**
-     * @param string $blockRoot
-     */
-    public function setBlockRoot($blockRoot)
-    {
-        $this->blockRoot = $blockRoot;
-    }
 
     /**
      * Configure the service name (admin_code) of the admin service for the embedded slides
@@ -82,7 +67,7 @@ class SlideshowBlockAdmin extends AbstractBlockAdmin
         if (null === $this->getParentFieldDescription()) {
             $formMapper
                 ->with('form.group_general')
-                    ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->blockRoot, 'choice_list' => array(), 'select_root_node' => true))
+                    ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
                     ->add('name', 'text')
                 ->end()
             ;

--- a/Admin/ReferenceBlockAdmin.php
+++ b/Admin/ReferenceBlockAdmin.php
@@ -33,9 +33,9 @@ class ReferenceBlockAdmin extends AbstractBlockAdmin
     {
         $formMapper
             ->with('form.group_general')
-            ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->contentRoot, 'choice_list' => array(), 'select_root_node' => true))
+            ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
             ->add('name', 'text')
-            ->add('referencedBlock', 'doctrine_phpcr_odm_tree', array('choice_list' => array(), 'required' => false, 'root_node' => $this->contentRoot))
+            ->add('referencedBlock', 'doctrine_phpcr_odm_tree', array('choice_list' => array(), 'required' => false, 'root_node' => $this->getRootPath()))
             ->end()
         ;
     }

--- a/Admin/SimpleBlockAdmin.php
+++ b/Admin/SimpleBlockAdmin.php
@@ -33,7 +33,7 @@ class SimpleBlockAdmin extends AbstractBlockAdmin
     {
         $formMapper
             ->with('form.group_general')
-            ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->contentRoot, 'choice_list' => array(), 'select_root_node' => true))
+            ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
             ->add('name', 'text')
             ->add('title', 'text')
             ->add('body', 'textarea')

--- a/Admin/StringBlockAdmin.php
+++ b/Admin/StringBlockAdmin.php
@@ -30,7 +30,7 @@ class StringBlockAdmin extends AbstractBlockAdmin
     {
         $formMapper
             ->with('form.group_general')
-            ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->contentRoot, 'choice_list' => array(), 'select_root_node' => true))
+            ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
             ->add('name', 'text')
             ->add('body', 'textarea')
             ->end()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Changelog
   You can either adjust your content to match ``%embed-block|block-identifier|end%``
   or (not recommended) configure `twig.cmf_embed_blocks.prefix` and `.postfix`
   to match the previous values `<span>%embed-block:"` and `"%</span>`.
+* **2013-08-31**: [Configuration] The persistence.phpcr.content_basepath was
+  removed. It was used inconsistently with block_basepath. One is enough. If
+  you configure content_basepath, remove it from the configuration, if you
+  relied on CoreBundle to configure this for us, just make sure to update
+  CoreBundle as well.
 
 1.0.0-RC1
 ---------

--- a/DependencyInjection/CmfBlockExtension.php
+++ b/DependencyInjection/CmfBlockExtension.php
@@ -85,7 +85,6 @@ class CmfBlockExtension extends Extension implements PrependExtensionInterface
             'container_admin_class' => 'container_admin.class',
             'reference_admin_class' => 'reference_admin.class',
             'action_admin_class' => 'action_admin.class',
-            'content_basepath' => 'content_basepath',
             'block_basepath' => 'block_basepath',
             'manager_name' => 'manager_name',
         );

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,7 +32,6 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('phpcr')
                             ->children()
                                 ->scalarNode('enabled')->defaultNull()->end()
-                                ->scalarNode('content_basepath')->defaultValue('/cms/content')->end()
                                 ->scalarNode('block_basepath')->defaultValue('/cms/content')->end()
                                 ->scalarNode('manager_name')->defaultNull()->end()
                                 ->scalarNode('simple_document_class')->defaultNull()->end()

--- a/Resources/config/admin-imagine.xml
+++ b/Resources/config/admin-imagine.xml
@@ -28,7 +28,7 @@
                 <argument>cmf_block.imagine.imagine_admin</argument>
             </call>
 
-            <call method="setBlockRoot">
+            <call method="setRootPath">
                 <argument>%cmf_block.persistence.phpcr.block_basepath%</argument>
             </call>
         </service>
@@ -43,8 +43,8 @@
                 <argument type="service" id="sonata.admin.route.path_info_slashes" />
             </call>
 
-            <call method="setRoot">
-                <argument>%cmf_block.persistence.phpcr.content_basepath%</argument>
+            <call method="setRootPath">
+                <argument>%cmf_block.persistence.phpcr.block_basepath%</argument>
             </call>
         </service>
 

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -39,8 +39,8 @@
                 <argument type="service" id="sonata.admin.route.path_info_slashes" />
             </call>
 
-            <call method="setContentRoot">
-                <argument>%cmf_block.persistence.phpcr.content_basepath%</argument>
+            <call method="setRootPath">
+                <argument>%cmf_block.persistence.phpcr.block_basepath%</argument>
             </call>
         </service>
 
@@ -54,8 +54,8 @@
                 <argument type="service" id="sonata.admin.route.path_info_slashes" />
             </call>
 
-            <call method="setContentRoot">
-                <argument>%cmf_block.persistence.phpcr.content_basepath%</argument>
+            <call method="setRootPath">
+                <argument>%cmf_block.persistence.phpcr.block_basepath%</argument>
             </call>
         </service>
 
@@ -69,8 +69,8 @@
                 <argument type="service" id="sonata.admin.route.path_info_slashes" />
             </call>
 
-            <call method="setContentRoot">
-                <argument>%cmf_block.persistence.phpcr.content_basepath%</argument>
+            <call method="setRootPath">
+                <argument>%cmf_block.persistence.phpcr.block_basepath%</argument>
             </call>
         </service>
 
@@ -84,8 +84,8 @@
                 <argument type="service" id="sonata.admin.route.path_info_slashes" />
             </call>
 
-            <call method="setContentRoot">
-                <argument>%cmf_block.persistence.phpcr.content_basepath%</argument>
+            <call method="setRootPath">
+                <argument>%cmf_block.persistence.phpcr.block_basepath%</argument>
             </call>
         </service>
 
@@ -99,8 +99,8 @@
                 <argument type="service" id="sonata.admin.route.path_info_slashes" />
             </call>
 
-            <call method="setContentRoot">
-                <argument>%cmf_block.persistence.phpcr.content_basepath%</argument>
+            <call method="setRootPath">
+                <argument>%cmf_block.persistence.phpcr.block_basepath%</argument>
             </call>
         </service>
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "doctrine/phpcr-bundle" :"1.0.*",
         "doctrine/phpcr-odm": "1.0.*",
         "sonata-project/block-bundle": "~2.2.4",
-        "symfony-cmf/core-bundle": "~1.0.0-RC1"
+        "symfony-cmf/core-bundle": "~1.0.0-RC4"
     },
     "require-dev": {
         "symfony-cmf/testing": "1.0.*",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

**Depends on https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/167 , https://github.com/symfony-cmf/CoreBundle/pull/89**

Use the root path provided by the base admin, get rid of some weird parameter duplication.
