### PR TITLE
make the PhpcrBlockLoader synchronized instead of using the container

### DIFF
--- a/Block/PhpcrBlockLoader.php
+++ b/Block/PhpcrBlockLoader.php
@@ -5,7 +5,7 @@ namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 use Doctrine\Common\Persistence\ManagerRegistry;
 
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
@@ -24,9 +24,9 @@ use Sonata\BlockBundle\Exception\BlockNotFoundException;
 class PhpcrBlockLoader implements BlockLoaderInterface
 {
     /**
-     * @var ContainerInterface
+     * @var Request
      */
-    protected $container;
+    protected $request;
 
     /**
      * @var null|LoggerInterface
@@ -62,7 +62,6 @@ class PhpcrBlockLoader implements BlockLoaderInterface
     protected $emptyBlockType;
 
     /**
-     * @param ContainerInterface       $container
      * @param ManagerRegistry          $managerRegistry
      * @param SecurityContextInterface $securityContext the publish workflow
      *      checker to check if menu items are published.
@@ -70,17 +69,20 @@ class PhpcrBlockLoader implements BlockLoaderInterface
      * @param null                     $emptyBlockType  set this to a block type name if you want empty blocks returned when no block is found
      */
     public function __construct(
-        ContainerInterface $container,
         ManagerRegistry $managerRegistry,
         SecurityContextInterface $securityContext,
         LoggerInterface $logger = null,
         $emptyBlockType = null
     ) {
-        $this->container        = $container;
         $this->managerRegistry  = $managerRegistry;
         $this->securityContext  = $securityContext;
         $this->logger           = $logger;
         $this->emptyBlockType   = $emptyBlockType;
+    }
+
+    public function setRequest(Request $request = null)
+    {
+        $this->request = $request;
     }
 
     /**
@@ -209,10 +211,10 @@ class PhpcrBlockLoader implements BlockLoaderInterface
             return $name;
         }
 
-        if ($this->container->has('request')
-            && $this->container->get('request')->attributes->has('contentDocument')
+        if ($this->request
+            && $this->request->attributes->has('contentDocument')
         ) {
-            $currentPage = $this->container->get('request')->attributes->get('contentDocument');
+            $currentPage = $this->request->attributes->get('contentDocument');
 
             return $this->getObjectManager()
                 ->getUnitOfWork()

--- a/DependencyInjection/CmfBlockExtension.php
+++ b/DependencyInjection/CmfBlockExtension.php
@@ -105,7 +105,7 @@ class CmfBlockExtension extends Extension implements PrependExtensionInterface
         }
 
         $blockLoader = $container->getDefinition('cmf.block.service');
-        $blockLoader->replaceArgument(1, new Reference('doctrine_phpcr'));
+        $blockLoader->replaceArgument(0, new Reference('doctrine_phpcr'));
         $blockLoader->addMethodCall('setManagerName', array('%cmf_block.persistence.phpcr.manager_name%'));
 
         $bundles = $container->getParameter('kernel.bundles');

--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -12,7 +12,6 @@
 
         <service id="cmf.block.service" class="Symfony\Cmf\Bundle\BlockBundle\Block\PhpcrBlockLoader">
             <tag name="sonata.block.loader" />
-            <argument type="service" id="service_container" />
             <argument type="service" id="doctrine-phpcr" />
             <argument type="service" id="cmf_core.publish_workflow.checker"/>
             <argument type="service" id="logger" on-invalid="ignore" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | see travis |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

we should avoid unnecessary dependencies on the DI container.
