### PR TITLE
make imagine and slideshow classes configurable like the rest

### DIFF
--- a/DependencyInjection/CmfBlockExtension.php
+++ b/DependencyInjection/CmfBlockExtension.php
@@ -81,10 +81,15 @@ class CmfBlockExtension extends Extension implements PrependExtensionInterface
             'container_document_class' => 'container_document.class',
             'reference_document_class' => 'reference_document.class',
             'action_document_class' => 'action_document.class',
+            'imagine_document_class' => 'imagine_document.class',
+            'slideshow_document_class' => 'slideshow_document.class',
             'simple_admin_class' => 'simple_admin.class',
             'container_admin_class' => 'container_admin.class',
             'reference_admin_class' => 'reference_admin.class',
             'action_admin_class' => 'action_admin.class',
+            'imagine_admin_class' => 'imagine_admin.class',
+            'slideshow_admin_class' => 'slideshow_admin.class',
+
             'block_basepath' => 'block_basepath',
             'manager_name' => 'manager_name',
         );

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,8 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('container_document_class')->defaultNull()->end()
                                 ->scalarNode('reference_document_class')->defaultNull()->end()
                                 ->scalarNode('action_document_class')->defaultNull()->end()
+                                ->scalarNode('slideshow_document_class')->defaultNull()->end()
+                                ->scalarNode('imagine_document_class')->defaultNull()->end()
 
                                 ->enumNode('use_sonata_admin')
                                     ->values(array(true, false, 'auto'))
@@ -49,6 +51,8 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('container_admin_class')->defaultNull()->end()
                                 ->scalarNode('reference_admin_class')->defaultNull()->end()
                                 ->scalarNode('action_admin_class')->defaultNull()->end()
+                                ->scalarNode('slideshow_admin_class')->defaultNull()->end()
+                                ->scalarNode('imagine_admin_class')->defaultNull()->end()
                             ->end()
                         ->end()
                     ->end()

--- a/Resources/config/admin-imagine.xml
+++ b/Resources/config/admin-imagine.xml
@@ -5,19 +5,19 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="cmf_block.imagine.slideshow_admin.class">Symfony\Cmf\Bundle\BlockBundle\Admin\Imagine\SlideshowBlockAdmin</parameter>
-        <parameter key="cmf_block.slideshow_document.class">Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\SlideshowBlock</parameter>
+        <parameter key="cmf_block.persistence.phpcr.slideshow_admin.class">Symfony\Cmf\Bundle\BlockBundle\Admin\Imagine\SlideshowBlockAdmin</parameter>
+        <parameter key="cmf_block.persistence.phpcr.slideshow_document.class">Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\SlideshowBlock</parameter>
 
-        <parameter key="cmf_block.imagine.imagine_admin.class">Symfony\Cmf\Bundle\BlockBundle\Admin\Imagine\ImagineBlockAdmin</parameter>
-        <parameter key="cmf_block.imagine_document.class">Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ImagineBlock</parameter>
+        <parameter key="cmf_block.persistence.phpcr.imagine_admin.class">Symfony\Cmf\Bundle\BlockBundle\Admin\Imagine\ImagineBlockAdmin</parameter>
+        <parameter key="cmf_block.persistence.phpcr.imagine_document.class">Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ImagineBlock</parameter>
     </parameters>
 
     <services>
 
-        <service id="cmf_block.imagine.slideshow_admin" class="%cmf_block.imagine.slideshow_admin.class%">
+        <service id="cmf_block.imagine.slideshow_admin" class="%cmf_block.persistence.phpcr.slideshow_admin.class%">
             <tag name="sonata.admin" manager_type="doctrine_phpcr" group="dashboard.cmf" label_catalogue="CmfBlockBundle" label="dashboard.label_slideshow_block" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument/>
-            <argument>%cmf_block.slideshow_document.class%</argument>
+            <argument>%cmf_block.persistence.phpcr.slideshow_document.class%</argument>
             <argument>SonataAdminBundle:CRUD</argument>
 
             <call method="setRouteBuilder">
@@ -33,10 +33,10 @@
             </call>
         </service>
 
-        <service id="cmf_block.imagine.imagine_admin" class="%cmf_block.imagine.imagine_admin.class%">
+        <service id="cmf_block.imagine.imagine_admin" class="%cmf_block.persistence.phpcr.imagine_admin.class%">
             <tag name="sonata.admin" manager_type="doctrine_phpcr" group="dashboard.cmf" label_catalogue="CmfBlockBundle" label="dashboard.label_imagine_block" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument/>
-            <argument>%cmf_block.imagine_document.class%</argument>
+            <argument>%cmf_block.persistence.phpcr.imagine_document.class%</argument>
             <argument>SonataAdminBundle:CRUD</argument>
 
             <call method="setRouteBuilder">

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -4,10 +4,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <!-- simple block service is reused for imagine items -->
+        <parameter key="cmf_block.service.imagine.class">Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService</parameter>
+    </parameters>
+
     <services>
 
-        <!-- simple block service is reused for imagine items -->
-        <service id="cmf.block.imagine" class="Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService">
+        <service id="cmf.block.imagine" class="%cmf_block.service.imagine.class%">
             <tag name="sonata.block" />
             <argument>cmf.block.imagine</argument>
             <argument type="service" id="templating" />

--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -6,11 +6,12 @@
 
     <parameters>
         <parameter key="cmf_block.persistence.phpcr.manager_name">null</parameter>
+        <parameter key="cmf_block.persistence.phpcr.block_loader.class">Symfony\Cmf\Bundle\BlockBundle\Block\PhpcrBlockLoader</parameter>
     </parameters>
 
     <services>
 
-        <service id="cmf.block.service" class="Symfony\Cmf\Bundle\BlockBundle\Block\PhpcrBlockLoader">
+        <service id="cmf.block.service" class="%cmf_block.persistence.phpcr.block_loader.class%">
             <tag name="sonata.block.loader" />
             <argument type="service" id="doctrine-phpcr" />
             <argument type="service" id="cmf_core.publish_workflow.checker"/>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,30 +10,37 @@
         <parameter key="cmf_block.templating.helper.block.class">Symfony\Cmf\Bundle\BlockBundle\Templating\Helper\CmfBlockHelper</parameter>
         <parameter key="cmf_block.fragment.renderer.action.class">Symfony\Cmf\Bundle\BlockBundle\Fragment\ActionFragmentRenderer</parameter>
         <parameter key="cmf_block.fragment.path">/_cmf_block_fragment</parameter>
+        <parameter key="cmf_block.service.simple.class">Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService</parameter>
+        <parameter key="cmf_block.service.string.class">Symfony\Cmf\Bundle\BlockBundle\Block\StringBlockService</parameter>
+        <parameter key="cmf_block.service.container.class">Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService</parameter>
+        <parameter key="cmf_block.service.reference.class">Symfony\Cmf\Bundle\BlockBundle\Block\ReferenceBlockService</parameter>
+        <parameter key="cmf_block.service.action.class">Symfony\Cmf\Bundle\BlockBundle\Block\ActionBlockService</parameter>
+        <!--container block service is reused for slideshows -->
+        <parameter key="cmf_block.service.slideshow.class">Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService</parameter>
     </parameters>
 
     <services>
 
-        <service id="cmf.block.simple" class="Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService">
+        <service id="cmf.block.simple" class="%cmf_block.service.simple.class%">
             <tag name="sonata.block" />
             <argument>cmf.block.simple</argument>
             <argument type="service" id="templating" />
         </service>
 
-        <service id="cmf.block.string" class="Symfony\Cmf\Bundle\BlockBundle\Block\StringBlockService">
+        <service id="cmf.block.string" class="%cmf_block.service.string.class%">
             <tag name="sonata.block" />
             <argument>cmf.block.string</argument>
             <argument type="service" id="templating" />
         </service>
 
-        <service id="cmf.block.container" class="Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService">
+        <service id="cmf.block.container" class="%cmf_block.service.container.class%">
             <tag name="sonata.block" />
             <argument>cmf.block.container</argument>
             <argument type="service" id="templating" />
             <argument type="service" id="sonata.block.renderer" />
         </service>
 
-        <service id="cmf.block.reference" class="Symfony\Cmf\Bundle\BlockBundle\Block\ReferenceBlockService">
+        <service id="cmf.block.reference" class="%cmf_block.service.reference.class%">
             <tag name="sonata.block" />
             <argument>cmf.block.reference</argument>
             <argument type="service" id="templating" />
@@ -41,7 +48,7 @@
             <argument type="service" id="sonata.block.context_manager" />
         </service>
 
-        <service id="cmf.block.action" class="Symfony\Cmf\Bundle\BlockBundle\Block\ActionBlockService">
+        <service id="cmf.block.action" class="%cmf_block.service.action.class%">
             <tag name="sonata.block" />
             <tag name="cmf_request_aware" />
             <argument>cmf.block.action</argument>
@@ -49,8 +56,7 @@
             <argument type="service" id="fragment.handler" />
         </service>
 
-        <!--container block service is reused for slideshows -->
-        <service id="cmf.block.slideshow" class="Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService">
+        <service id="cmf.block.slideshow" class="%cmf_block.service.slideshow.class%">
             <tag name="sonata.block" />
             <argument>cmf.block.slideshow</argument>
             <argument type="service" id="templating" />


### PR DESCRIPTION
fix service definition files to use parameters for class names

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | see travis |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The BC break is normalizing the parameter names for slideshow and imagine block and admins to have the persistence.phpcr prefix. this affects slideshow_admin, slideshow_document, imagine_admin and imagine_document.
