### PR TITLE
ContainerBlock - add hasChildren method

### DIFF
--- a/Doctrine/Phpcr/ContainerBlock.php
+++ b/Doctrine/Phpcr/ContainerBlock.php
@@ -106,4 +106,12 @@ class ContainerBlock extends AbstractBlock
     {
         $this->children->removeElement($child);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasChildren()
+    {
+        return count($this->children) > 0;
+    }
 }


### PR DESCRIPTION
Added `ContainerBlock::hasChildren`, before it would return false. Now it can be used for the TTL cache cascading to the parents fixed in SonataBlockBundle PR: https://github.com/sonata-project/SonataBlockBundle/pull/96

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
