### PR TITLE
Allow use of block settings.class to be used as a class of the wrapping div

### DIFF
--- a/Resources/views/Block/block_base.html.twig
+++ b/Resources/views/Block/block_base.html.twig
@@ -1,7 +1,7 @@
 {% if block.dashifiedId is defined %}
-<div id="block{{ block.dashifiedId }}" class="cmf-block {{ block.dashifiedType }}">
+<div id="block{{ block.dashifiedId }}" class="cmf-block {{ block.settings.class|default('') }} {{ block.dashifiedType }}">
 {% else %}
-<div id="cms-block-{{ block.id }}" class="cms-block cms-block-element">
+<div id="cms-block-{{ block.id }}" class="cms-block cms-block-element {{ block.settings.class|default('') }}">
 {% endif %}
     {% block block %}EMPTY CONTENT{% endblock %}
 </div>


### PR DESCRIPTION
I think the settings array would be a good place to also put class info for output in it?
This way every existing block and every newly created can use the class attribute to change the class of the outer div.
