### PR TITLE
Fixed template to prevent additional </div> beeing generated, which brea...

### DIFF
--- a/Resources/views/Block/block_container.html.twig
+++ b/Resources/views/Block/block_container.html.twig
@@ -22,9 +22,6 @@
                     <div class="{{ settings.divisible_class }}">
                 {% endif %}
             {% endif %}
-            {% if loop.last %}
-                </div>{# end row #}
-            {% endif %}
         {% endif %}
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
...ks the dom

Without having this removed i get a broken dom for e.g.:

i have a content page using a container block as direct child and three child blocks inside there and use 

```
{{ sonata_block_render({ 'name': 'myContainerBlock' }, {}) }} 
```

to render it
