### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/framework-bundle": ">=2.2.4,<3.0",
         "doctrine/phpcr-bundle" :">=1.0.0,<1.2-dev",
         "doctrine/phpcr-odm": ">=1.0.0,<1.2-dev",
-        "sonata-project/block-bundle": ">=2.2.4,<2.2.8",
+        "sonata-project/block-bundle": ">=2.2.4,<=2.2.8",
         "symfony-cmf/core-bundle": "1.0.*"
     },
     "conflict": {


### PR DESCRIPTION
SonataBlockBundle 2.2.7 is missing the MenuBlockService which causes an exception. 2.2.8 fixes this issue.   

[InvalidArgumentException]  
  Unable to load class "Sonata\BlockBundle\Block\Service\MenuBlockService"
