### PR TITLE
adjust to sanity check in phpcr-odm

### DIFF
--- a/Doctrine/Phpcr/ImagineBlock.php
+++ b/Doctrine/Phpcr/ImagineBlock.php
@@ -149,6 +149,7 @@ class ImagineBlock extends AbstractBlock implements TranslatableInterface
             // TODO: https://github.com/doctrine/phpcr-odm/pull/262
             $this->image->copyContentFromFile($image);
         } elseif ($image instanceof ImageInterface) {
+            $image->setName('image'); // ensure document has right name
             $this->image = $image;
         } else {
             $this->image = new Image();


### PR DESCRIPTION
the mediabundle creates the document with the name of the uploaded file. but because we map as a child, we need to ensure its at the right name.
