### PR TITLE
update to PSR-4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* **2014-06-06**: Updated to PSR-4 autoloading
+
 1.1.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,10 @@
         "eko/feedbundle": "When using the RssBlock"
     },
     "autoload":{
-        "psr-0":{
-            "Symfony\\Cmf\\Bundle\\BlockBundle": ""
+        "psr-4":{
+            "Symfony\\Cmf\\Bundle\\BlockBundle\\": ""
         }
     },
-    "target-dir": "Symfony/Cmf/Bundle/BlockBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "1.1-dev"


### PR DESCRIPTION
This pull request updates `composer.json` to use PSR-4 instead of PSR-0 as described in symfony-cmf/symfony-cmf#185.
