### PR TITLE
fix AbstractBlock::getParent

### DIFF
--- a/Model/AbstractBlock.php
+++ b/Model/AbstractBlock.php
@@ -332,7 +332,7 @@ abstract class AbstractBlock implements
      */
     public function getParent()
     {
-        if ($parent = $this->getParentObject() instanceof BlockInterface) {
+        if (($parent = $this->getParentObject()) instanceof BlockInterface) {
             return $parent;
         }
 


### PR DESCRIPTION
AbstractBlock::getParent returned boolean instead of BlockInterface
