### PR TITLE
add missing configureListFields method for imagineBlockAdmin

### DIFF
--- a/Admin/Imagine/ImagineBlockAdmin.php
+++ b/Admin/Imagine/ImagineBlockAdmin.php
@@ -20,6 +20,19 @@ use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ImagineBlock;
  */
 class ImagineBlockAdmin extends AbstractBlockAdmin
 {
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        parent::configureListFields($listMapper);
+        $listMapper
+            ->addIdentifier('id', 'text')
+            ->add('name', 'text')
+        ;
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |

Hi, here is a small fix into imagineBlockAdmin where no field was displayed in imagine block lists

Thanks
