### PR TITLE
Fix translation

### DIFF
--- a/Resources/translations/CmfBlockBundle.de.xliff
+++ b/Resources/translations/CmfBlockBundle.de.xliff
@@ -37,11 +37,6 @@
                 <target>Textblock</target>
             </trans-unit>
 
-            <trans-unit id="dashboard.label_menu_block">
-                <source>dashboard.label_menu_block</source>
-                <target>MenuBlock</target>
-            </trans-unit>
-
             <trans-unit id="breadcrumb.link_slideshow_block_list">
                 <source>breadcrumb.link_slideshow_block_list</source>
                 <target>Slideshow Blöcke</target>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Have no clue why the BlockBundles translation is used for the translation in sonata-admin-blocks, but i got an error after the last `composer update` that the translation file can't be parsed, this PR fixes that problem.
