### PR TITLE
extended 3.x sonata block bundle support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/framework-bundle": "^2.3",
         "doctrine/phpcr-bundle" :"^1.0",
         "doctrine/phpcr-odm": "^1.0",
-        "sonata-project/block-bundle": ">=2.2.12,<2.5",
+        "sonata-project/block-bundle": ">=2.2.12,<3.1",
         "symfony-cmf/core-bundle": "^1.1"
     },
     "conflict": {


### PR DESCRIPTION
This is sonata block for 3.x support, so it works fine with admin bundle 3.x