### PR TITLE
multiple embed blocks fix

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,6 +8,7 @@
         <parameter key="cmf_block.rss_controller.class">Symfony\Cmf\Bundle\BlockBundle\Controller\RssController</parameter>
         <parameter key="cmf_block.twig_extension.class">Symfony\Cmf\Bundle\BlockBundle\Twig\Extension\CmfBlockExtension</parameter>
         <parameter key="cmf_block.templating.helper.block.class">Symfony\Cmf\Bundle\BlockBundle\Templating\Helper\CmfBlockHelper</parameter>
+        <parameter key="cmf_block.templating.helper.embed_blocks_parser">Symfony\Cmf\Bundle\BlockBundle\Templating\Helper\EmbedBlocksParser</parameter>
         <parameter key="cmf_block.service.simple.class">Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService</parameter>
         <parameter key="cmf_block.service.string.class">Symfony\Cmf\Bundle\BlockBundle\Block\StringBlockService</parameter>
         <parameter key="cmf_block.service.container.class">Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService</parameter>
@@ -74,10 +75,14 @@
             <tag name="twig.extension"/>
         </service>
 
-        <service id="cmf_block.templating.helper.block" class="%cmf_block.templating.helper.block.class%">
-            <argument type="service" id="sonata.block.templating.helper" />
+        <service id="cmf_block.templating.helper.embed_blocks_parser" class="%cmf_block.templating.helper.embed_blocks_parser%">
             <argument>%cmf_block.twig.cmf_embed_blocks.prefix%</argument>
             <argument>%cmf_block.twig.cmf_embed_blocks.postfix%</argument>
+        </service>
+
+        <service id="cmf_block.templating.helper.block" class="%cmf_block.templating.helper.block.class%">
+            <argument type="service" id="sonata.block.templating.helper" />
+            <argument type="service" id="cmf_block.templating.helper.embed_blocks_parser" />
             <argument type="service" id="logger" />
 
             <tag name="templating.helper" alias="cmf_block" />

--- a/Templating/Helper/EmbedBlocksParser.php
+++ b/Templating/Helper/EmbedBlocksParser.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Templating\Helper;
+
+/**
+ * Finds all the embedded blocks.
+ *
+ * @author Viorel Craescu <viorel@craescu.com>
+ */
+class EmbedBlocksParser
+{
+    private $prefix;
+    private $postfix;
+
+    /**
+     * EmbedBlocksParser constructor.
+     *
+     * @param $prefix
+     * @param $postfix
+     */
+    public function __construct($prefix, $postfix)
+    {
+        $this->prefix = $prefix;
+        $this->postfix = $postfix;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @param mixed $prefix
+     *
+     * @return EmbedBlocksParser
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPostfix()
+    {
+        return $this->postfix;
+    }
+
+    /**
+     * @param mixed $postfix
+     *
+     * @return EmbedBlocksParser
+     */
+    public function setPostfix($postfix)
+    {
+        $this->postfix = $postfix;
+
+        return $this;
+    }
+
+    /**
+     * @param $text
+     * @param callable $callback
+     *
+     * @return string
+     */
+    public function parse($text, callable $callback)
+    {
+        $segments = $this->segmentize($text);
+        foreach ($segments as &$segment) {
+            if (!is_array($segment)) {
+                continue;
+            }
+
+            $segment[0] = $callback($segment[0]);
+            $segment = implode('', $segment);
+        }
+
+        return implode('', $segments);
+    }
+
+    /**
+     * @param $text
+     *
+     * @return array
+     */
+    protected function segmentize($text)
+    {
+        $segments = explode($this->prefix, $text);
+        foreach ($segments as $index => &$segment) {
+            if ($index == 0) {
+                continue;
+            }
+
+            if (strpos($segment, $this->postfix) !== false) {
+                $segment = array_filter(explode($this->postfix, $segment));
+                $segment[0] = trim($segment[0]);
+            }
+        }
+
+        return $segments;
+    }
+}

--- a/Tests/Unit/Templating/Helper/EmbedBlocksParserTest.php
+++ b/Tests/Unit/Templating/Helper/EmbedBlocksParserTest.php
@@ -1,0 +1,145 @@
+<?php
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Tests\Unit\Templating\Helper;
+
+use Symfony\Cmf\Bundle\BlockBundle\Templating\Helper\EmbedBlocksParser;
+
+class EmbedBlocksParserTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var EmbedBlocksParser */
+    protected $parser;
+
+    public function setUp()
+    {
+        $this->parser = new EmbedBlocksParser('%embed-block|', '|end%');
+    }
+
+    /**
+     * @dataProvider segmentizeProvider
+     *
+     * @param $text
+     * @param $expected
+     */
+    public function testSegmentize($text, $expected)
+    {
+        $actual = $this->callMethod($this->parser, 'segmentize', [$text]);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @dataProvider parseProvider
+     *
+     * @param $text
+     * @param $expected
+     */
+    public function testParse($text, $expected)
+    {
+        $actual = $this->parser->parse(
+            $text,
+            function ($id) {
+                return 'this_is_block_content';
+            }
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @return array
+     */
+    public function parseProvider()
+    {
+        return [
+            [
+                '%embed-block|/cms/blocks/test|end%',
+                'this_is_block_content',
+            ],
+            [
+                '<div>%embed-block|/cms/blocks/test|end%<div>%embed-block|/cms/blocks/test|end%</div>',
+                '<div>this_is_block_content<div>this_is_block_content</div>',
+            ],
+            [
+                '/cms/blocks/test|end%<div>/cms/blocks/test|end%</div>',
+                '/cms/blocks/test|end%<div>/cms/blocks/test|end%</div>',
+            ],
+            [
+                "%embed-block|/cms/blocks/test\n\n   |end%<div>/cms/blocks/test|end%</div>",
+                'this_is_block_content<div>/cms/blocks/test</div>',
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function segmentizeProvider()
+    {
+        return [
+            [
+                '%embed-block|/cms/blocks/test|end%',
+                ['', ['/cms/blocks/test']],
+            ],
+            [
+                '<div>%embed-block|/cms/blocks/test|end%</div>',
+                ['<div>', ['/cms/blocks/test', '</div>']],
+            ],
+            [
+                '<div>%embed-block|/cms/blocks/test|end%<div>/cms/blocks/test|end%</div>',
+                ['<div>', ['/cms/blocks/test', '<div>/cms/blocks/test', '</div>']],
+            ],
+            [
+                '/cms/blocks/test|end%<div>/cms/blocks/test|end%</div>',
+                ['/cms/blocks/test|end%<div>/cms/blocks/test|end%</div>'],
+            ],
+            [
+                "%embed-block|/cms/blocks/test\n\n   |end%<div>/cms/blocks/test|end%</div>",
+                ['', ['/cms/blocks/test', '<div>/cms/blocks/test', '</div>']],
+            ],
+            [
+                '<div>%embed-block|/cms/blocks/test1|end%</div><div>%embed-block|/cms/blocks/test2|end%</div><div>%embed-block|/cms/blocks/test3|end%</div>',
+                [
+                    '<div>',
+                    ['/cms/blocks/test1', '</div><div>'],
+                    ['/cms/blocks/test2', '</div><div>'],
+                    ['/cms/blocks/test3', '</div>'],
+                ],
+            ],
+            [
+                '<div>%embed-block|/cms/blocks/test1|end%</div><div>/cms/blocks/test2|end%</div><div>%embed-block|/cms/blocks/test3|end%</div>',
+                [
+                    '<div>',
+                    ['/cms/blocks/test1', '</div><div>/cms/blocks/test2', '</div><div>'],
+                    ['/cms/blocks/test3', '</div>'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param $object
+     * @param string $method
+     * @param array  $params
+     *
+     * @return mixed
+     */
+    private function callMethod($object, $method, array $params)
+    {
+        $methodCall = \Closure::bind(
+            function () use ($method) {
+                return call_user_func_array([$this, $method], func_get_args());
+            },
+            $object,
+            $object
+        );
+
+        return call_user_func_array($methodCall, $params);
+    }
+}


### PR DESCRIPTION
Embed multiple blocks it's not working when you use the default prefix and postfix: %embed-block|, |end%. 
Also, preg_* functions should be avoided parsing large files due their length limit.