### PR TITLE
Remove class parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* **2016-06-21**: [BC BREAK] Removed all `*.class` parameters.
+
 1.3.0
 -----
 

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -4,13 +4,9 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="cmf_block.admin_extension.cache.class">Symfony\Cmf\Bundle\BlockBundle\Admin\Extension\BlockCacheExtension</parameter>
-    </parameters>
-
     <services>
 
-        <service id="cmf_block.admin_extension.cache" class="%cmf_block.admin_extension.cache.class%">
+        <service id="cmf_block.admin_extension.cache" class="Symfony\Cmf\Bundle\BlockBundle\Admin\Extension\BlockCacheExtension">
             <tag name="sonata.admin.extension"/>
         </service>
 

--- a/Resources/config/cache.xml
+++ b/Resources/config/cache.xml
@@ -29,7 +29,7 @@
             <argument type="service" id="sonata.block.context_manager" />
         </service>
 
-        <service id="cmf.block.cache.js_sync" class="Symfony\Cmf\Bundle\BlockBundle\Cache\BlockJsCache" >
+        <service id="cmf.block.cache.js_sync" class="Symfony\Cmf\Bundle\BlockBundle\Cache\BlockJsCache">
             <tag name="sonata.cache" />
 
             <argument type="service" id="router" />
@@ -39,7 +39,7 @@
             <argument>true</argument>
         </service>
 
-        <service id="cmf.block.cache.js_async" class="Symfony\Cmf\Bundle\BlockBundle\Cache\BlockJsCache" >
+        <service id="cmf.block.cache.js_async" class="Symfony\Cmf\Bundle\BlockBundle\Cache\BlockJsCache">
             <tag name="sonata.cache" />
 
             <argument type="service" id="router" />

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -4,14 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <!-- simple block service is reused for imagine items -->
-        <parameter key="cmf_block.service.imagine.class">Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService</parameter>
-    </parameters>
-
     <services>
 
-        <service id="cmf.block.imagine" class="%cmf_block.service.imagine.class%">
+        <service id="cmf.block.imagine" class="Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.imagine</argument>
             <argument type="service" id="templating" />

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -4,13 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="cmf_block.service.menu.class">Symfony\Cmf\Bundle\BlockBundle\Block\MenuBlockService</parameter>
-    </parameters>
-
     <services>
 
-        <service id="cmf.block.menu" class="%cmf_block.service.menu.class%">
+        <service id="cmf.block.menu" class="Symfony\Cmf\Bundle\BlockBundle\Block\MenuBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.reference</argument>
             <argument type="service" id="templating" />

--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -6,12 +6,11 @@
 
     <parameters>
         <parameter key="cmf_block.persistence.phpcr.manager_name">null</parameter>
-        <parameter key="cmf_block.persistence.phpcr.block_loader.class">Symfony\Cmf\Bundle\BlockBundle\Block\PhpcrBlockLoader</parameter>
     </parameters>
 
     <services>
 
-        <service id="cmf.block.service" class="%cmf_block.persistence.phpcr.block_loader.class%">
+        <service id="cmf.block.service" class="Symfony\Cmf\Bundle\BlockBundle\Block\PhpcrBlockLoader">
             <tag name="sonata.block.loader" />
             <argument type="service" id="doctrine-phpcr" />
             <argument type="service" id="cmf_core.publish_workflow.checker"/>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,34 +4,21 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="cmf_block.rss_controller.class">Symfony\Cmf\Bundle\BlockBundle\Controller\RssController</parameter>
-        <parameter key="cmf_block.twig_extension.class">Symfony\Cmf\Bundle\BlockBundle\Twig\Extension\CmfBlockExtension</parameter>
-        <parameter key="cmf_block.templating.helper.block.class">Symfony\Cmf\Bundle\BlockBundle\Templating\Helper\CmfBlockHelper</parameter>
-        <parameter key="cmf_block.service.simple.class">Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService</parameter>
-        <parameter key="cmf_block.service.string.class">Symfony\Cmf\Bundle\BlockBundle\Block\StringBlockService</parameter>
-        <parameter key="cmf_block.service.container.class">Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService</parameter>
-        <parameter key="cmf_block.service.reference.class">Symfony\Cmf\Bundle\BlockBundle\Block\ReferenceBlockService</parameter>
-        <parameter key="cmf_block.service.action.class">Symfony\Cmf\Bundle\BlockBundle\Block\ActionBlockService</parameter>
-        <!--container block service is reused for slideshows -->
-        <parameter key="cmf_block.service.slideshow.class">Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService</parameter>
-    </parameters>
-
     <services>
 
-        <service id="cmf.block.simple" class="%cmf_block.service.simple.class%">
+        <service id="cmf.block.simple" class="Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.simple</argument>
             <argument type="service" id="templating" />
         </service>
 
-        <service id="cmf.block.string" class="%cmf_block.service.string.class%">
+        <service id="cmf.block.string" class="Symfony\Cmf\Bundle\BlockBundle\Block\StringBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.string</argument>
             <argument type="service" id="templating" />
         </service>
 
-        <service id="cmf.block.container" class="%cmf_block.service.container.class%">
+        <service id="cmf.block.container" class="Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.container</argument>
             <argument type="service" id="templating" />
@@ -39,7 +26,7 @@
             <argument/><!-- for template construct -->
         </service>
 
-        <service id="cmf.block.reference" class="%cmf_block.service.reference.class%">
+        <service id="cmf.block.reference" class="Symfony\Cmf\Bundle\BlockBundle\Block\ReferenceBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.reference</argument>
             <argument type="service" id="templating" />
@@ -47,7 +34,7 @@
             <argument type="service" id="sonata.block.context_manager" />
         </service>
 
-        <service id="cmf.block.action" class="%cmf_block.service.action.class%">
+        <service id="cmf.block.action" class="Symfony\Cmf\Bundle\BlockBundle\Block\ActionBlockService">
             <tag name="sonata.block" />
             <argument type="service" id="request_stack" />
             <argument>cmf.block.action</argument>
@@ -55,7 +42,7 @@
             <argument type="service" id="fragment.handler" />
         </service>
 
-        <service id="cmf.block.slideshow" class="%cmf_block.service.slideshow.class%">
+        <service id="cmf.block.slideshow" class="Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.slideshow</argument>
             <argument type="service" id="templating" />
@@ -63,18 +50,18 @@
             <argument>CmfBlockBundle:Block:block_slideshow.html.twig</argument>
         </service>
 
-        <service id="cmf.block.rss_controller" class="%cmf_block.rss_controller.class%" >
+        <service id="cmf.block.rss_controller" class="Symfony\Cmf\Bundle\BlockBundle\Controller\RssController" >
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>
         </service>
 
-        <service id="cmf_block.twig.embed_extension" class="%cmf_block.twig_extension.class%">
+        <service id="cmf_block.twig.embed_extension" class="Symfony\Cmf\Bundle\BlockBundle\Twig\Extension\CmfBlockExtension">
             <argument type="service" id="cmf_block.templating.helper.block"/>
             <tag name="twig.extension"/>
         </service>
 
-        <service id="cmf_block.templating.helper.block" class="%cmf_block.templating.helper.block.class%">
+        <service id="cmf_block.templating.helper.block" class="Symfony\Cmf\Bundle\BlockBundle\Templating\Helper\CmfBlockHelper">
             <argument type="service" id="sonata.block.templating.helper" />
             <argument>%cmf_block.twig.cmf_embed_blocks.prefix%</argument>
             <argument>%cmf_block.twig.cmf_embed_blocks.postfix%</argument>


### PR DESCRIPTION
This one is a bit weird, as it has lots of class parameters which are configurable. The same applies to some other bundles (it seems to be very inconsistent).

This is mainly done for the admin stuff, so I guess we don't have to worry about it as everything related to sonata admin is extracted from the main bundles anyways.