### PR TITLE
Use sonata.templating service from SonataBlockBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
         "doctrine/phpcr-bundle": "^1.4|^2.0",
         "doctrine/phpcr-odm": "^1.4.2|^2.0",
-        "sonata-project/block-bundle": "^3.3",
+        "sonata-project/block-bundle": "^3.11",
         "symfony-cmf/core-bundle": "^2.0"
     },
     "require-dev": {

--- a/src/Resources/config/menu.xml
+++ b/src/Resources/config/menu.xml
@@ -9,7 +9,7 @@
         <service id="cmf.block.menu" class="Symfony\Cmf\Bundle\BlockBundle\Block\MenuBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.reference</argument>
-            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.templating" />
         </service>
 
     </services>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -9,19 +9,19 @@
         <service id="cmf.block.simple" class="Symfony\Cmf\Bundle\BlockBundle\Block\SimpleBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.simple</argument>
-            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.templating" />
         </service>
 
         <service id="cmf.block.string" class="Symfony\Cmf\Bundle\BlockBundle\Block\StringBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.string</argument>
-            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.templating" />
         </service>
 
         <service id="cmf.block.container" class="Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.container</argument>
-            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.templating" />
             <argument type="service" id="sonata.block.renderer" />
             <argument/><!-- for template construct -->
         </service>
@@ -29,7 +29,7 @@
         <service id="cmf.block.reference" class="Symfony\Cmf\Bundle\BlockBundle\Block\ReferenceBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.reference</argument>
-            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.templating" />
             <argument type="service" id="sonata.block.renderer" />
             <argument type="service" id="sonata.block.context_manager" />
         </service>
@@ -38,14 +38,14 @@
             <tag name="sonata.block" />
             <argument type="service" id="request_stack" />
             <argument>cmf.block.action</argument>
-            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.templating" />
             <argument type="service" id="fragment.handler" />
         </service>
 
         <service id="cmf.block.slideshow" class="Symfony\Cmf\Bundle\BlockBundle\Block\ContainerBlockService">
             <tag name="sonata.block" />
             <argument>cmf.block.slideshow</argument>
-            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.templating" />
             <argument type="service" id="sonata.block.renderer" />
             <argument>CmfBlockBundle:Block:block_slideshow.html.twig</argument>
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features
| Bug fix?      | no
| New feature?  | yes?
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

A `templating` service can be used only after manual configuration of `symfony/framework-bundle`, so if another bundle use it, then it cannot have a recipe for Symfony Flex.

To create a recipe for `sonata-project/block-bundle` a new service `sonata.templating` was created to replace `templating` service, see https://github.com/sonata-project/SonataBlockBundle/pull/457 for details. `sonata.templating` service can be used instead of `templating` without activating Templating Component in `config/packages/framework.yaml`. New service supports both template path notations (templating 'bundle:section:template.format.engine' ang twig namespacing syntax)

All Sonata bundles, that use Templating Component already use `sonata.templating` service in current stable branches. Also, SonataBlock will use `twig` service directly only after new major release, see https://github.com/sonata-project/SonataBlockBundle/pull/476