### PR TITLE
[WIP] Updates to create recipe for Symfony Flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "php": "^7.1",
         "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
         "doctrine/phpcr-bundle": "^1.4|^2.0",
-        "doctrine/phpcr-odm": "^1.4.2|^2.0",
         "sonata-project/block-bundle": "^3.11",
         "symfony-cmf/core-bundle": "^2.0"
     },
     "require-dev": {
+        "doctrine/phpcr-odm": "^1.4.2|^2.0",
         "symfony-cmf/testing": "^2.1",
         "symfony-cmf/menu-bundle": "^2.1",
         "symfony/phpunit-bridge": "^3.3 || ^4.0",

--- a/src/CmfBlockBundle.php
+++ b/src/CmfBlockBundle.php
@@ -25,7 +25,7 @@ class CmfBlockBundle extends Bundle
     {
         $container->addCompilerPass(new ValidationPass());
 
-        if (class_exists(DoctrinePhpcrMappingsPass::class) && $container->hasParameter('cmf_block.persistence.phpcr.manager_name')) {
+        if (class_exists(DoctrinePhpcrMappingsPass::class)) {
             $container->addCompilerPass(
                 DoctrinePhpcrMappingsPass::createXmlMappingDriver(
                     [

--- a/src/CmfBlockBundle.php
+++ b/src/CmfBlockBundle.php
@@ -25,7 +25,7 @@ class CmfBlockBundle extends Bundle
     {
         $container->addCompilerPass(new ValidationPass());
 
-        if (class_exists('Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\DoctrinePhpcrMappingsPass')) {
+        if (class_exists(DoctrinePhpcrMappingsPass::class) && $container->hasParameter('cmf_block.persistence.phpcr.manager_name')) {
             $container->addCompilerPass(
                 DoctrinePhpcrMappingsPass::createXmlMappingDriver(
                     [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master", for 2.1 release
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

In https://github.com/symfony-cmf/symfony-cmf/issues/260 i tried to create minimal recipes for SymfonyCMF bundles used in `symfony-cmf/symfony-cmf`

A recipe for `symfony-cmf/block-bundle` could could contain these lines:

```yaml
cmf_block:
    persistence:
        phpcr:
            enabled: true
```

In this PR i moved `doctrine/phpcr-odm` to `require-dev` section of composer.json, because it require `phpcr/phpcr-implementation` virtual package, and if this requirement will be in `require` section, this bundle will never have a recipe.

Also with this PR `DoctrinePhpcrMappingsPass` compiler pass could be added only if `cmf_block.persistence.phpcr.manager_name` parameter exists